### PR TITLE
Separate console/PuppetDB, new puppetlabs/postgresql, enable PE packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Module Description
 ------------------
 
 It will do the following things:
- - Install postgresql 9.2
+ - Install postgresql 9.4
  - Install postgresql-contrib package
  - Create databases and users that are required by PE
  - Install the citext module on the rbac databse which is required by PE
    - https://docs.puppetlabs.com/pe/latest/install_upgrading_notes.html#a-note-about-rbac-node-classifier-and-external-postgresql
+ - Install the pgstattuple extension on puppetdb and classifer databases
 
 Example Usage
 ------------

--- a/README.md
+++ b/README.md
@@ -58,7 +58,27 @@ Sets the password for the pe-rbac user to connect to the pe-rbac database
 ####`activity_db_password`
 Sets the password for the pe-activity user to connect to the pe-activity database
 
-####`postgresql_version`
-The version of postgresql to install.  Defaults to 9.2.  
+####`orchestrator_db_password`
+Sets the password for the pe-orchestrator user to connect to the pe-orchestrator database
 
-If you are using PE 2015.2 you need to install 9.4
+####`postgresql_version`
+The version of postgresql to install.  Defaults to 9.4.
+
+####`use_pe_packages`
+If set to `true`, PostgreSQL will be installed using the Puppet Enterprise
+packages and paths. Note that for this option to work, you must have the
+pe-postgresql and pe-postgresql-contrib packages available in the configured
+machine's package repositories. Typically agent machines will have access to
+these packages through the `pe_repo` class. Defaults to `false`.
+
+###`console`
+Whether or not to manage the PE console databases. If set to `false`, the
+`pe-activity`, `pe-classifier`, `pe-rbac`, and `pe-orchestrator` databases will
+not be managed. This is useful when installing the Console and PuppetDB
+databases on separate servers. Defaults to `true`.
+
+###`puppetdb`
+Whether or not to manage the PE PuppetDB database. If set to `false`, the
+`pe-puppetdb` database will not be managed. This is useful when installing the
+Console and PuppetDB databases on separate servers. Defaults to `true`.
+

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -50,4 +50,14 @@ class pe_external_postgresql::console (
     password => postgresql_password('pe-activity', $activity_db_password ),
   }
 
+  # Orchestrator database
+  postgresql::server::role { 'pe-orchestrator':
+    password_hash => postgresql_password('pe-orchestrator', $orchestrator_db_password ),
+  }
+
+  postgresql::server::db { 'pe-orchestrator':
+    user     => 'pe-orchestrator',
+    password => postgresql_password('pe-orchestrator', $orchestrator_db_password ),
+  }
+
 }

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -1,0 +1,53 @@
+class pe_external_postgresql::console (
+  $postgres_root_password   = 'password',
+  $classifier_db_password   = 'password',
+  $rbac_db_password         = 'password',
+  $activity_db_password     = 'password',
+  $orchestrator_db_password = 'password',
+) {
+
+  # Classifier database
+  postgresql::server::role { 'pe-classifier':
+    password_hash => postgresql_password('pe-classifier', $classifier_db_password ),
+  }
+
+  postgresql::server::db { 'pe-classifier':
+    user     => 'pe-classifier',
+    password => postgresql_password('pe-classifier', $classifier_db_password ),
+  }
+
+  postgresql::server::extension { 'pe-classifier-pgstattuple':
+    ensure    => present,
+    extension => 'pgstattuple',
+    database  => 'pe-classifier',
+    require   => Postgresql::Server::Db['pe-classifier'],
+  }
+
+  # RBAC Database
+  postgresql::server::role { 'pe-rbac':
+    password_hash => postgresql_password('pe-rbac', $rbac_db_password ),
+  }
+
+  postgresql::server::db { 'pe-rbac':
+    user     => 'pe-rbac',
+    password => postgresql_password('pe-rbac', $rbac_db_password ),
+  }
+
+  postgresql::server::extension { 'pe-rbac-citext':
+    ensure    => present,
+    extension => 'citext',
+    database  => 'pe-rbac',
+    require   => Postgresql::Server::Db['pe-rbac'],
+  }
+
+  # Activity service database
+  postgresql::server::role { 'pe-activity':
+    password_hash => postgresql_password('pe-activity', $activity_db_password ),
+  }
+
+  postgresql::server::db { 'pe-activity':
+    user     => 'pe-activity',
+    password => postgresql_password('pe-activity', $activity_db_password ),
+  }
+
+}

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -11,9 +11,16 @@ class pe_external_postgresql::console (
     password_hash => postgresql_password('pe-classifier', $classifier_db_password ),
   }
 
+  postgresql::server::tablespace { 'pe-classifier':
+    location => "${postgresql::globals::datadir}/pe-classifier",
+    require  => Class['postgresql::server'],
+  }
+
   postgresql::server::db { 'pe-classifier':
-    user     => 'pe-classifier',
-    password => postgresql_password('pe-classifier', $classifier_db_password ),
+    user       => 'pe-classifier',
+    password   => postgresql_password('pe-classifier', $classifier_db_password ),
+    tablespace => 'pe-classifier',
+    require    => Postgresql::Server::Tablespace['pe-classifier'],
   }
 
   postgresql::server::extension { 'pe-classifier-pgstattuple':
@@ -28,9 +35,16 @@ class pe_external_postgresql::console (
     password_hash => postgresql_password('pe-rbac', $rbac_db_password ),
   }
 
+  postgresql::server::tablespace { 'pe-rbac':
+    location => "${postgresql::globals::datadir}/pe-rbac",
+    require  => Class['postgresql::server'],
+  }
+
   postgresql::server::db { 'pe-rbac':
-    user     => 'pe-rbac',
-    password => postgresql_password('pe-rbac', $rbac_db_password ),
+    user       => 'pe-rbac',
+    password   => postgresql_password('pe-rbac', $rbac_db_password ),
+    tablespace => 'pe-rbac',
+    require    => Postgresql::Server::Tablespace['pe-rbac'],
   }
 
   postgresql::server::extension { 'pe-rbac-citext':
@@ -45,9 +59,16 @@ class pe_external_postgresql::console (
     password_hash => postgresql_password('pe-activity', $activity_db_password ),
   }
 
+  postgresql::server::tablespace { 'pe-activity':
+    location => "${postgresql::globals::datadir}/pe-activity",
+    require  => Class['postgresql::server'],
+  }
+
   postgresql::server::db { 'pe-activity':
-    user     => 'pe-activity',
-    password => postgresql_password('pe-activity', $activity_db_password ),
+    user       => 'pe-activity',
+    password   => postgresql_password('pe-activity', $activity_db_password ),
+    tablespace => 'pe-activity',
+    require    => Postgresql::Server::Tablespace['pe-activity'],
   }
 
   # Orchestrator database
@@ -55,9 +76,16 @@ class pe_external_postgresql::console (
     password_hash => postgresql_password('pe-orchestrator', $orchestrator_db_password ),
   }
 
+  postgresql::server::tablespace { 'pe-orchestrator':
+    location => "${postgresql::globals::datadir}/pe-orchestrator",
+    require  => Class['postgresql::server'],
+  }
+
   postgresql::server::db { 'pe-orchestrator':
-    user     => 'pe-orchestrator',
-    password => postgresql_password('pe-orchestrator', $orchestrator_db_password ),
+    user       => 'pe-orchestrator',
+    password   => postgresql_password('pe-orchestrator', $orchestrator_db_password ),
+    tablespace => 'pe-orchestrator',
+    require    => Postgresql::Server::Tablespace['pe-orchestrator'],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,10 @@ class pe_external_postgresql (
   include postgresql::server::contrib
 
   # PuppetDB Database
+  postgresql::server::role { 'pe-puppetdb':
+    password_hash => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
+  }
+
   postgresql::server::db { 'pe-puppetdb':
     user     => 'pe-puppetdb',
     password => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
@@ -45,7 +49,11 @@ class pe_external_postgresql (
 
 
   # Classifier database
-  postgresql::server::database{ 'pe-classifier':
+  postgresql::server::role { 'pe-classifier':
+    password_hash => postgresql_password('pe-classifier', $classifier_db_password ),
+  }
+
+  postgresql::server::db { 'pe-classifier':
     user     => 'pe-classifier',
     password => postgresql_password('pe-classifier', $classifier_db_password ),
   }
@@ -58,6 +66,10 @@ class pe_external_postgresql (
   }
 
   # RBAC Database
+  postgresql::server::role { 'pe-rbac':
+    password_hash => postgresql_password('pe-rbac', $rbac_db_password ),
+  }
+
   postgresql::server::db { 'pe-rbac':
     user     => 'pe-rbac',
     password => postgresql_password('pe-rbac', $rbac_db_password ),
@@ -71,6 +83,10 @@ class pe_external_postgresql (
   }
 
   # Activity service database
+  postgresql::server::role { 'pe-activity':
+    password_hash => postgresql_password('pe-activity', $activity_db_password ),
+  }
+
   postgresql::server::db { 'pe-activity':
     user     => 'pe-activity',
     password => postgresql_password('pe-activity', $activity_db_password ),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 class pe_external_postgresql (
   $postgres_root_password = 'password',
   $puppetdb_db_password   = 'password',
-  $console_db_password    = 'password',
   $classifier_db_password = 'password',
   $rbac_db_password       = 'password',
   $activity_db_password   = 'password',
@@ -37,25 +36,6 @@ class pe_external_postgresql (
     db      => 'pe-puppetdb',
     unless  => "select * from pg_extension where extname='pg_trgm'",
     require => Postgresql::Server::Db['pe-puppetdb'],
-  }
-
-  postgresql::server::role { 'console':
-    password_hash => postgresql_password('console', $console_db_password ),
-  }
-
-  postgresql::server::db { 'console':
-    user     => 'console',
-    password => postgresql_password('console', $console_db_password ),
-  }
-
-  #console_auth is only here for compatibility with older PE releases < 3.7
-  postgresql::server::role { 'console_auth':
-    password_hash => postgresql_password('console_auth', 'password'),
-  }
-
-  postgresql::server::db { 'console_auth':
-    user     => 'console_auth',
-    password => postgresql_password('console_auth', 'password'),
   }
 
   postgresql::server::role { 'pe-classifier':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,20 +32,20 @@ class pe_external_postgresql (
   postgresql::server::extension { 'pe-puppetdb-pg_trgm':
     ensure    => present,
     extension => 'pg_trgm',
-    db        => 'pe-puppetdb',
+    database  => 'pe-puppetdb',
     require   => Postgresql::Server::Db['pe-puppetdb'],
   }
 
   postgresql::server::extension { 'pe-puppetdb-pgstattuple':
     ensure    => present,
     extension => 'pgstattuple',
-    db        => 'pe-puppetdb',
+    database  => 'pe-puppetdb',
     require   => Postgresql::Server::Db['pe-puppetdb'],
   }
 
 
   # Classifier database
-  postgresql::server::db { 'pe-classifier':
+  postgresql::server::database{ 'pe-classifier':
     user     => 'pe-classifier',
     password => postgresql_password('pe-classifier', $classifier_db_password ),
   }
@@ -53,7 +53,7 @@ class pe_external_postgresql (
   postgresql::server::extension { 'pe-classifier-pgstattuple':
     ensure    => present,
     extension => 'pgstattuple',
-    db        => 'pe-classifier',
+    database  => 'pe-classifier',
     require   => Postgresql::Server::Db['pe-classifier'],
   }
 
@@ -66,7 +66,7 @@ class pe_external_postgresql (
   postgresql::server::extension { 'pe-rbac-citext':
     ensure    => present,
     extension => 'citext',
-    db        => 'pe-rbac',
+    database  => 'pe-rbac',
     require   => Postgresql::Server::Db['pe-rbac'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class pe_external_postgresql (
   $rbac_db_password         = 'password',
   $activity_db_password     = 'password',
   $orchestrator_db_password = 'password',
-  $postgresql_version     = '9.2',
+  $postgresql_version     = '9.4',
 ) {
 
   class { 'postgresql::globals':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,6 @@ class pe_external_postgresql (
   $use_pe_packages          = false,
   $console                  = true,
   $puppetdb                 = true,
-
 ) {
 
 
@@ -27,6 +26,7 @@ class pe_external_postgresql (
     $datadir = "${pgsql_dir}/${postgresql_version}/data"
     $confdir = "${pgsql_dir}/${postgresql_version}/data"
     $psql_path = "${bindir}/psql"
+    $manage_package_repo = false
   } else {
     $bindir = undef
     $pgsql_dir = undef
@@ -41,6 +41,7 @@ class pe_external_postgresql (
     $datadir = undef
     $confdir = undef
     $psql_path = undef
+    $manage_package_repo = undef
   }
 
   class { 'postgresql::globals':
@@ -57,6 +58,7 @@ class pe_external_postgresql (
     datadir              => $datadir,
     confdir              => $confdir,
     psql_path            => $psql_path,
+    manage_package_repo  => $manage_package_repo,
   } ->
   class { 'postgresql::server':
     ip_mask_deny_postgres_user => '0.0.0.0/32',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 class pe_external_postgresql (
-  $postgres_root_password = 'password',
-  $puppetdb_db_password   = 'password',
-  $classifier_db_password = 'password',
-  $rbac_db_password       = 'password',
-  $activity_db_password   = 'password',
+  $postgres_root_password   = 'password',
+  $puppetdb_db_password     = 'password',
+  $classifier_db_password   = 'password',
+  $rbac_db_password         = 'password',
+  $activity_db_password     = 'password',
+  $orchestrator_db_password = 'password',
   $postgresql_version     = '9.2',
 ) {
 
@@ -22,51 +23,54 @@ class pe_external_postgresql (
 
   include postgresql::server::contrib
 
-  postgresql::server::role { 'pe-puppetdb':
-    password_hash => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
-  }
-
+  # PuppetDB Database
   postgresql::server::db { 'pe-puppetdb':
     user     => 'pe-puppetdb',
     password => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
   }
 
-  $pg_trgm_cmd = 'CREATE EXTENSION pg_trgm;'
-  postgresql_psql { $pg_trgm_cmd:
-    db      => 'pe-puppetdb',
-    unless  => "select * from pg_extension where extname='pg_trgm'",
-    require => Postgresql::Server::Db['pe-puppetdb'],
+  postgresql::server::extension { 'pe-puppetdb-pg_trgm':
+    ensure    => present,
+    extension => 'pg_trgm',
+    db        => 'pe-puppetdb',
+    require   => Postgresql::Server::Db['pe-puppetdb'],
   }
 
-  postgresql::server::role { 'pe-classifier':
-    password_hash => postgresql_password('pe-classifier', $classifier_db_password ),
+  postgresql::server::extension { 'pe-puppetdb-pgstattuple':
+    ensure    => present,
+    extension => 'pgstattuple',
+    db        => 'pe-puppetdb',
+    require   => Postgresql::Server::Db['pe-puppetdb'],
   }
 
+
+  # Classifier database
   postgresql::server::db { 'pe-classifier':
     user     => 'pe-classifier',
     password => postgresql_password('pe-classifier', $classifier_db_password ),
   }
 
-  postgresql::server::role { 'pe-rbac':
-    password_hash => postgresql_password('pe-rbac', $rbac_db_password ),
+  postgresql::server::extension { 'pe-classifier-pgstattuple':
+    ensure    => present,
+    extension => 'pgstattuple',
+    db        => 'pe-classifier',
+    require   => Postgresql::Server::Db['pe-classifier'],
   }
 
+  # RBAC Database
   postgresql::server::db { 'pe-rbac':
     user     => 'pe-rbac',
     password => postgresql_password('pe-rbac', $rbac_db_password ),
   }
 
-  $citext_cmd = 'CREATE EXTENSION citext;'
-  postgresql_psql { $citext_cmd:
-    db      => 'pe-rbac',
-    unless  => "select * from pg_extension where extname='citext'",
-    require => Postgresql::Server::Db['pe-rbac'],
+  postgresql::server::extension { 'pe-rbac-citext':
+    ensure    => present,
+    extension => 'citext',
+    db        => 'pe-rbac',
+    require   => Postgresql::Server::Db['pe-rbac'],
   }
 
-  postgresql::server::role { 'pe-activity':
-    password_hash => postgresql_password('pe-activity', $activity_db_password ),
-  }
-
+  # Activity service database
   postgresql::server::db { 'pe-activity':
     user     => 'pe-activity',
     password => postgresql_password('pe-activity', $activity_db_password ),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class pe_external_postgresql (
     $manage_package_repo = undef
   }
 
-  class { 'postgresql::globals':
+  class { '::postgresql::globals':
     version              => $postgresql_version,
     bindir               => $bindir,
     client_package_name  => $client_package_name,
@@ -59,7 +59,7 @@ class pe_external_postgresql (
     psql_path            => $psql_path,
     manage_package_repo  => $manage_package_repo,
   } ->
-  class { 'postgresql::server':
+  class { '::postgresql::server':
     ip_mask_deny_postgres_user => '0.0.0.0/32',
     ip_mask_allow_all_users    => '0.0.0.0/0',
     listen_addresses           => '*',
@@ -71,7 +71,7 @@ class pe_external_postgresql (
   include postgresql::server::contrib
 
   if $puppetdb {
-    class { 'pe_external_postgresql::puppetdb':
+    class { '::pe_external_postgresql::puppetdb':
       postgres_root_password => $postgres_root_password,
       puppetdb_db_password   => $puppetdb_db_password,
       require                => Class['pe_external_postgresql'],
@@ -79,7 +79,7 @@ class pe_external_postgresql (
   }
 
   if $console {
-    class { 'pe_external_postgresql::console':
+    class { '::pe_external_postgresql::console':
       postgres_root_password   => $postgres_root_password,
       classifier_db_password   => $classifier_db_password,
       rbac_db_password         => $rbac_db_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,13 +6,57 @@ class pe_external_postgresql (
   $activity_db_password     = 'password',
   $orchestrator_db_password = 'password',
   $postgresql_version       = '9.4',
+  $use_pe_packages          = false,
   $console                  = true,
   $puppetdb                 = true,
+
 ) {
 
+
+  if $use_pe_packages {
+    $bindir = '/opt/puppetlabs/server/bin'
+    $pgsql_dir = '/opt/puppetlabs/server/data/postgresql'
+    $client_package_name = 'pe-postgresql'
+    $server_package_name = 'pe-postgresql-server'
+    $contrib_package_name = 'pe-postgresql-contrib'
+    $default_database = 'pe-postgres'
+    $user = 'pe-postgres'
+    $group = 'pe-postgres'
+    $service_name = 'pe-postgresql'
+
+    $datadir = "${pgsql_dir}/${postgresql_version}/data"
+    $confdir = "${pgsql_dir}/${postgresql_version}/data"
+    $psql_path = "${bindir}/psql"
+  } else {
+    $bindir = undef
+    $pgsql_dir = undef
+    $client_package_name = undef
+    $server_package_name = undef
+    $contrib_package_name = undef
+    $default_database = undef
+    $user = undef
+    $group = undef
+    $service_name = undef
+
+    $datadir = undef
+    $confdir = undef
+    $psql_path = undef
+  }
+
   class { 'postgresql::globals':
-    manage_package_repo => true,
-    version             => $postgresql_version,
+    manage_package_repo  => true,
+    version              => $postgresql_version,
+    bindir               => $bindir,
+    client_package_name  => $client_package_name,
+    server_package_name  => $server_package_name,
+    contrib_package_name => $contrib_package_name,
+    default_database     => $default_database,
+    user                 => $user,
+    group                => $group,
+    service_name         => $service_name,
+    datadir              => $datadir,
+    confdir              => $confdir,
+    psql_path            => $psql_path,
   } ->
   class { 'postgresql::server':
     ip_mask_deny_postgres_user => '0.0.0.0/32',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,6 @@ class pe_external_postgresql (
   }
 
   class { 'postgresql::globals':
-    manage_package_repo  => true,
     version              => $postgresql_version,
     bindir               => $bindir,
     client_package_name  => $client_package_name,

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -8,9 +8,15 @@ class pe_external_postgresql::puppetdb (
     password_hash => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
   }
 
+  postgresql::server::tablespace { 'pe-puppetdb':
+    location => "${::postgresql::globals::datadir}/pe-puppetdb",
+    require  => Class['postgresql::server'],
+  }
+
   postgresql::server::db { 'pe-puppetdb':
     user     => 'pe-puppetdb',
     password => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
+    require  => Postgresql::Server::Tablespace['pe-puppetdb'],
   }
 
   postgresql::server::extension { 'pe-puppetdb-pg_trgm':

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -14,9 +14,10 @@ class pe_external_postgresql::puppetdb (
   }
 
   postgresql::server::db { 'pe-puppetdb':
-    user     => 'pe-puppetdb',
-    password => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
-    require  => Postgresql::Server::Tablespace['pe-puppetdb'],
+    user       => 'pe-puppetdb',
+    tablespace => 'pe-puppetdb',
+    password   => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
+    require    => Postgresql::Server::Tablespace['pe-puppetdb'],
   }
 
   postgresql::server::extension { 'pe-puppetdb-pg_trgm':

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -1,0 +1,29 @@
+class pe_external_postgresql::puppetdb (
+  $postgres_root_password   = 'password',
+  $puppetdb_db_password     = 'password',
+) {
+
+  # PuppetDB Database
+  postgresql::server::role { 'pe-puppetdb':
+    password_hash => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
+  }
+
+  postgresql::server::db { 'pe-puppetdb':
+    user     => 'pe-puppetdb',
+    password => postgresql_password('pe-puppetdb', $puppetdb_db_password ),
+  }
+
+  postgresql::server::extension { 'pe-puppetdb-pg_trgm':
+    ensure    => present,
+    extension => 'pg_trgm',
+    database  => 'pe-puppetdb',
+    require   => Postgresql::Server::Db['pe-puppetdb'],
+  }
+
+  postgresql::server::extension { 'pe-puppetdb-pgstattuple':
+    ensure    => present,
+    extension => 'pgstattuple',
+    database  => 'pe-puppetdb',
+    require   => Postgresql::Server::Db['pe-puppetdb'],
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_external_postgresql",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "author": "npwalker",
   "summary": "A module for installing an external postgresql node for Puppet Enterprise",
   "license": "Apache 2.0",
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/npwalker/pe_external_postgresql",
   "issues_url": "https://github.com/npwalker/pe_external_postgresql/issues",
   "dependencies": [
-    {"name":"puppetlabs-postgresql","version_requirement":">= 3.0.0"}
+    {"name":"puppetlabs-postgresql","version_requirement":">= 4.7.0"}
   ],
   "operatingsystem_support": [
     {
@@ -62,7 +62,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 2015.2.0"
     }
   ]
 }


### PR DESCRIPTION
This PR adds two new features and makes use of new features in puppetlabs/postgresql.
- Console and PuppetDB databases can be installed on separate servers
- Puppet Enterprise packages can be used to install and manage the database
- The `postgresql::server::extension` define is used to manage extensions. This requires using a later version of the puppetlabs/postgresql module to be released 2016-02-01.

The default version of PostgreSQL is updated to 9.4, and the supported PE version is bumped to 2015.2.0 or greater.
