### PR TITLE
(maint) Add max_connections parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Sets the password for the pe-orchestrator user to connect to the pe-orchestrator
 ####`postgresql_version`
 The version of postgresql to install.  Defaults to 9.4.
 
+####`max_connections`
+The amount of client connections PSQL will allow. Defaults to 200.
+
 ####`use_pe_packages`
 If set to `true`, PostgreSQL will be installed using the Puppet Enterprise
 packages and paths. Note that for this option to work, you must have the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class pe_external_postgresql (
   String  $activity_db_password     = 'password',
   String  $orchestrator_db_password = 'password',
   String  $postgresql_version       = '9.4',
+  Integer $max_connections          = 200,
   Boolean $use_pe_packages          = false,
   Boolean $console                  = true,
   Boolean $puppetdb                 = true,
@@ -64,6 +65,12 @@ class pe_external_postgresql (
     postgres_password          => $postgres_root_password,
     encoding                   => 'utf8',
     locale                     => 'en_US.utf8',
+  }
+
+  # Starting with PE 2016.1.1; a minimum of 200 max_connections
+  # is recommended
+  postgresql::server::config_entry { 'max_connections':
+    value => $max_connections,
   }
 
   include postgresql::server::contrib


### PR DESCRIPTION
Previous to this commit, the PSQL server setting 'max_connections' was
not managed and instead left to the user to tune. However, starting with
PE 2016.1.1, this value needs to be a minimum of 200 in order for PE to
work, as the default PE stack will consume more than 100 connections at
startup.
This commit adds a parameter to change it, with a default of 200.
