### PR TITLE
PE-18377 Add pgcrypto extension to rbac database

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,7 @@ class pe_external_postgresql (
     # RBAC Database
     pe_external_postgresql::database { 'pe-rbac':
       db_password => $rbac_db_password,
-      extensions  => [ 'citext' ],
+      extensions  => [ 'citext', 'pgcrypto'],
     }
 
     # Activity service database


### PR DESCRIPTION
PE 2016.5.0 requires pgcrypto extension on the rbac database.