### PR TITLE
Deprecate the module and prepare for PE 2017.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
+This Module is Deprecated
+-------------------------
+
+You can install a PostgreSQL node with the PE installer starting in PE 2016.2.  As far as I see it there are not many reasons to install an OSS PostgreSQL server any longer when PE will take care of it for you.  
+
+Here's a link to the docs on how to do that: https://docs.puppet.com/pe/latest/install_separate_pe_postgres.html
+
 Overview
 --------
 
-This puppet module will configure an external postgresql node for your Puppet Enterprise infrastructure.
+This puppet module will configure an external PostgreSQL node for your Puppet Enterprise infrastructure.
 
 Module Description
 ------------------
 
 It will do the following things:
- - Install postgresql 9.4
+ - Install postgresql 9.6
  - Install postgresql-contrib package
  - Create databases and users that are required by PE
  - Install the citext module on the rbac databse which is required by PE
    - https://docs.puppetlabs.com/pe/latest/install_upgrading_notes.html#a-note-about-rbac-node-classifier-and-external-postgresql
- - Install the pgcrypto extension on the puppetdb
+ - Install the pgcrypto extension on the pe-puppetdb database and the pe-rbac
 
 Example Usage
 ------------
@@ -23,8 +30,8 @@ In order to effectively use this module you will need to do the following in the
  - If you are installing a split installation you can install the puppet master node before installing this agent
  - If you are installing an all-in-one master you will need to install this agent and continue when it says it can't connect to the master
 2. Save something like the following to a file (maybe `/tmp/postgresql_setup.pp`) on your agent node but specify your own passwords
- - 
-		
+ -
+
 			class { 'pe_external_postgresql' :
 			  postgres_root_password   => 'pass1',
 			  puppetdb_db_password     => 'pass2',
@@ -33,56 +40,56 @@ In order to effectively use this module you will need to do the following in the
 			  activity_db_password     => 'pass5',
 			  orchestrator_db_password => 'pass6',
 			}
-		
+
 
 3. `puppet module install npwalker-pe_external_postgresql`
 4. Run `puppet apply /tmp/postgresql_setup.pp` on the agent node to install postgresql and setup the databases.
 
-###Class: pe_external_postgresql
+### Class: pe_external_postgresql
 
-####`postgres_root_password`
+#### `postgres_root_password`
 Sets the password for the postgres user.
 
-####`puppetdb_db_password`
-Sets the password for the puppetdb user to connect to the puppetdb database 
+#### `puppetdb_db_password`
+Sets the password for the puppetdb user to connect to the puppetdb database
 
-####`console_db_password`
+#### `console_db_password`
 Sets the password for the console user to connect to the console database
 
-####`classifier_db_password`
+#### `classifier_db_password`
 Sets the password for the pe-classifier user to connect to the pe-classifier database
 
-####`rbac_db_password`
+#### `rbac_db_password`
 Sets the password for the pe-rbac user to connect to the pe-rbac database
 
-####`activity_db_password`
+#### `activity_db_password`
 Sets the password for the pe-activity user to connect to the pe-activity database
 
-####`orchestrator_db_password`
+#### `orchestrator_db_password`
 Sets the password for the pe-orchestrator user to connect to the pe-orchestrator database
 
-####`postgresql_version`
+#### `postgresql_version`
 The version of postgresql to install.  Defaults to 9.4.
 
-####`use_pe_packages`
+#### `use_pe_packages`
 If set to `true`, PostgreSQL will be installed using the Puppet Enterprise
 packages and paths. Note that for this option to work, you must have the
 pe-postgresql and pe-postgresql-contrib packages available in the configured
 machine's package repositories. Typically agent machines will have access to
 these packages through the `pe_repo` class. Defaults to `false`.
 
-###`console`
+### `console`
 Whether or not to manage the PE console databases. If set to `false`, the
 `pe-activity`, `pe-classifier`, and `pe-rbac` databases will
 not be managed. This is useful when installing the Console and PuppetDB
 databases on separate servers. Defaults to `true`.
 
-###`puppetdb`
+### `puppetdb`
 Whether or not to manage the PE PuppetDB database. If set to `false`, the
 `pe-puppetdb` database will not be managed. This is useful when installing the
 Console and PuppetDB databases on separate servers. Defaults to `true`.
 
-###`orchestrator`
+### `orchestrator`
 Whether or not to manage the PE Orchestrator database. If set to `false`, the
 `pe-orchestrator` database will not be managed. I would expect users to place
 this database with the console database but want to leave the option to put it

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,12 +5,20 @@ class pe_external_postgresql (
   String  $rbac_db_password         = 'password',
   String  $activity_db_password     = 'password',
   String  $orchestrator_db_password = 'password',
-  String  $postgresql_version       = '9.4',
+  Optional[String] $postgresql_version = undef,
   Boolean $use_pe_packages          = false,
   Boolean $console                  = true,
   Boolean $puppetdb                 = true,
   Boolean $orchestrator             = true,
 ) {
+
+  #install postgresql 9.6 if > PE 2017.3 or if pe_server_version isn't
+  #specified, most likely from a puppet apply run.
+  if versioncmp( pick($facts['pe_server_version'],'9999.0.0'), '2017.3.0' ) >= 0 {
+    $_postgresql_version = pick($postgresql_version, '9.6')
+  } else {
+    $_postgresql_version = pick($postgresql_version, '9.4')
+  }
 
   if $use_pe_packages {
     $bindir               = '/opt/puppetlabs/server/bin'
@@ -39,11 +47,11 @@ class pe_external_postgresql (
     $datadir              = undef
     $confdir              = undef
     $psql_path            = undef
-    $manage_package_repo  = true 
+    $manage_package_repo  = true
   }
 
   class { '::postgresql::globals':
-    version              => $postgresql_version,
+    version              => $_postgresql_version,
     bindir               => $bindir,
     client_package_name  => $client_package_name,
     server_package_name  => $server_package_name,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_external_postgresql",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "author": "npwalker",
   "summary": "A module for installing an external postgresql node for Puppet Enterprise",
   "license": "Apache 2.0",
@@ -62,7 +62,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 2015.2.0"
+      "version_requirement": ">= 2017.3.0"
     }
   ]
 }


### PR DESCRIPTION
As laid out in the README, it doesn't make much sense to manage your own OSS PostgreSQL node with PE when PE can do it for you.   

So, this module is considered deprecated and installations using an OSS PostgreSQL node should migrate to a new PE install and then restore the existing database.  